### PR TITLE
Require pophint instead of pophint-config

### DIFF
--- a/bts.el
+++ b/bts.el
@@ -343,7 +343,7 @@
 (require 'dash)
 (require 's)
 (require 'pos-tip)
-(require 'pophint-config nil t)
+(require 'pophint nil t)
 
 (defgroup bts nil
   "A unified UI for various bug tracking systems."


### PR DESCRIPTION
`pophint-config.el' was removed in https://github.com/aki2o/emacs-pophint/commit/c7234fe367643d8d4d614c91c7a.